### PR TITLE
Add CI workflow for unit and integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Install ffmpeg
+        run: sudo apt-get install -y ffmpeg
+
       - name: Install Playwright Chromium
         run: pnpm --filter @git-glimpse/core exec playwright install chromium --with-deps
 


### PR DESCRIPTION
## Summary
This PR introduces a GitHub Actions CI workflow to automatically run unit and integration tests on pull requests.

## Key Changes
- Added `.github/workflows/ci.yml` with two separate jobs:
  - **unit-tests**: Runs unit tests on Node.js 20 using pnpm
  - **integration-tests**: Runs integration tests with Playwright, including:
    - Playwright Chromium browser installation
    - Example app server startup
    - Health check polling to ensure app readiness before running tests

## Implementation Details
- Both jobs use Node.js 20 and pnpm for dependency management
- Integration tests include a robust health check mechanism that polls `http://localhost:3000` up to 15 times with 1-second intervals
- The workflow triggers on pull request open and synchronize events
- Uses latest versions of standard GitHub Actions (checkout@v4, setup-node@v4, pnpm/action-setup@v4)

https://claude.ai/code/session_0161hwiY52dSwBergfZmniKA