### PR TITLE
fix: use explicit null check for pull_request in workflow if condition

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -16,7 +16,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
+       github.event.issue.pull_request != null &&
        contains(github.event.comment.body, '/glimpse'))
     permissions:
       pull-requests: write


### PR DESCRIPTION
GitHub Actions expression evaluator doesn't reliably coerce objects to boolean in compound && expressions. Changed from truthy check to explicit != null comparison.

https://claude.ai/code/session_01F7qRXukhynYjUukzhaBzSK