### PR TITLE
fix: remove PR head ref checkout for issue_comment events

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -26,8 +26,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # On issue_comment, check out the PR head ref (default branch otherwise has no trigger code)
-          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Checking out the PR head meant ./packages/action had old code from the PR branch (before trigger support). Letting issue_comment check out main (default) ensures the action code includes trigger handling. The diff still works via fetch-depth: 0 and API-fetched SHAs.

https://claude.ai/code/session_01F7qRXukhynYjUukzhaBzSK