### PR TITLE
fix: checkout PR head for app code, overlay action from main

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -26,6 +26,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
+
+      # On issue_comment we check out the PR head (for app code), but need
+      # the action from main (which has trigger support). The bundled dist
+      # includes all core logic, so restoring just packages/action/ suffices.
+      - name: Use latest action code from main
+        if: github.event_name == 'issue_comment'
+        run: git checkout origin/main -- packages/action/
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
For issue_comment events we need both:
- PR's code (to run the correct version of the app for recording)
- Main's packages/action/ (which has the trigger handling logic)

Solution: checkout PR head ref first, then git checkout just packages/action/ from origin/main. The bundled dist/index.js includes all core trigger logic so no other files needed.

https://claude.ai/code/session_01F7qRXukhynYjUukzhaBzSK