### PR TITLE
Refine script generation prompts for better timing and mouse movement

### DIFF
--- a/packages/core/src/generator/prompts.ts
+++ b/packages/core/src/generator/prompts.ts
@@ -24,7 +24,6 @@ export function buildScriptGenerationPrompt(options: ScriptPromptOptions): strin
 ## Rules
 - Navigate to the affected pages
 - Interact with new/changed UI elements (click buttons, fill forms, hover states)
-- Add \`await page.waitForTimeout(1500)\` pauses on key visual states so the recording captures them clearly
 - Use resilient selectors in priority order: text content > ARIA roles > test IDs > CSS classes
 - The script must be self-contained and immediately runnable
 - Total demo should be under ${options.maxDuration} seconds
@@ -32,6 +31,16 @@ export function buildScriptGenerationPrompt(options: ScriptPromptOptions): strin
 - Act as a real user: only interact through the UI using standard Playwright actions (navigate, click, type, hover). Never re-implement or simulate application features in the script.
 - Do NOT inject code into the page via \`page.evaluate\`, \`page.addInitScript\`, or inline \`<script>\` / \`<style>\` tags. The recording infrastructure handles visual overlays — the script should not.
 - Always call \`await page.waitForLoadState('networkidle')\` after navigation
+
+## Timing
+- Keep pauses short: use \`await page.waitForTimeout(300)\` between most actions
+- Only use a longer pause (\`await page.waitForTimeout(800)\`) directly after an interaction whose visual result (animation, state change, panel opening) is the point of the demo
+- Avoid stacking multiple pauses in a row — one pause per meaningful moment is enough
+
+## Mouse movement
+- Move the mouse naturally between interactions: before clicking or hovering a target, briefly move to a nearby point first so the cursor doesn't teleport
+- Use \`await page.mouse.move(x, y)\` for a single intermediate waypoint — keep it simple, one waypoint is enough
+- Coordinates should be plausible screen positions relative to the viewport (${options.viewport.width}x${options.viewport.height})
 
 ## Context
 - Base URL: ${options.baseUrl}


### PR DESCRIPTION
## Summary
Updated the script generation prompt instructions to provide more nuanced guidance on timing and mouse movement behavior, replacing a blanket pause recommendation with context-aware timing strategies.

## Key Changes
- **Removed** the generic instruction to add 1500ms pauses on key visual states
- **Added** a new "Timing" section with refined pause guidance:
  - Use short 300ms pauses between most actions
  - Reserve longer 800ms pauses only after interactions with visible results (animations, state changes, panel openings)
  - Discourage stacking multiple pauses in sequence
- **Added** a new "Mouse movement" section with natural cursor movement guidance:
  - Recommend moving the mouse to a nearby point before clicking/hovering to avoid teleporting
  - Use `page.mouse.move()` with a single intermediate waypoint
  - Ensure coordinates are plausible for the viewport dimensions

## Implementation Details
These changes improve the quality of generated scripts by:
1. Making pause timing more intentional and context-aware rather than uniform
2. Encouraging more natural user interaction patterns through intermediate mouse movements
3. Providing clearer constraints (single waypoint, plausible coordinates) to keep generated scripts realistic

https://claude.ai/code/session_01WpqwtdViucvCCdgxj6RCGG