### PR TITLE
fix: improve previewUrl resolution error messages and add tests

### DIFF
--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_TRIGGER,
   type GitGlimpseConfig,
 } from '@git-glimpse/core';
+import { resolveBaseUrl } from './resolve-base-url.js';
 
 function streamCommand(cmd: string, args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -224,34 +225,6 @@ async function run(): Promise<void> {
   }
 }
 
-export function resolveBaseUrl(
-  config: GitGlimpseConfig,
-  previewUrlOverride?: string
-): { url: string; error?: never } | { url?: never; error: string } {
-  const previewUrl = previewUrlOverride ?? config.app.previewUrl;
-  if (previewUrl) {
-    const resolved = process.env[previewUrl];
-    if (resolved === undefined) {
-      // previewUrl is a literal URL string, not an env var name
-      if (previewUrl.startsWith('http')) return { url: previewUrl };
-      return {
-        error: `app.previewUrl is set to "${previewUrl}" but it doesn't look like a URL and no env var with that name was found. ` +
-          `Set it to a full URL (e.g. "https://my-preview.vercel.app") or an env var name that is available in this workflow job.`,
-      };
-    }
-    if (!resolved.startsWith('http')) {
-      return {
-        error: `Env var "${previewUrl}" was found but its value "${resolved}" is not a valid URL. Expected a value starting with "http".`,
-      };
-    }
-    return { url: resolved };
-  }
-  if (config.app.readyWhen?.url) {
-    const u = new URL(config.app.readyWhen.url);
-    return { url: u.origin };
-  }
-  return { url: 'http://localhost:3000' };
-}
 
 async function startApp(
   startCommand: string,

--- a/packages/action/src/resolve-base-url.ts
+++ b/packages/action/src/resolve-base-url.ts
@@ -1,0 +1,31 @@
+import type { GitGlimpseConfig } from '../../core/src/config/schema.js';
+
+export function resolveBaseUrl(
+  config: GitGlimpseConfig,
+  previewUrlOverride?: string
+): { url: string; error?: never } | { url?: never; error: string } {
+  const previewUrl = previewUrlOverride ?? config.app.previewUrl;
+  if (previewUrl) {
+    const resolved = process.env[previewUrl];
+    if (resolved === undefined) {
+      // previewUrl is a literal URL string, not an env var name
+      if (previewUrl.startsWith('http')) return { url: previewUrl };
+      return {
+        error:
+          `app.previewUrl is set to "${previewUrl}" but it doesn't look like a URL and no env var with that name was found. ` +
+          `Set it to a full URL (e.g. "https://my-preview.vercel.app") or an env var name that is available in this workflow job.`,
+      };
+    }
+    if (!resolved.startsWith('http')) {
+      return {
+        error: `Env var "${previewUrl}" was found but its value "${resolved}" is not a valid URL. Expected a value starting with "http".`,
+      };
+    }
+    return { url: resolved };
+  }
+  if (config.app.readyWhen?.url) {
+    const u = new URL(config.app.readyWhen.url);
+    return { url: u.origin };
+  }
+  return { url: 'http://localhost:3000' };
+}

--- a/tests/unit/resolve-base-url.test.ts
+++ b/tests/unit/resolve-base-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { resolveBaseUrl } from '../../packages/action/src/index.js';
+import { resolveBaseUrl } from '../../packages/action/src/resolve-base-url.js';
 import type { GitGlimpseConfig } from '../../packages/core/src/config/schema.js';
 
 function makeConfig(app: GitGlimpseConfig['app']): GitGlimpseConfig {


### PR DESCRIPTION
When app.previewUrl is set to an env var name that isn't available in the workflow job, the action now fails with a descriptive message naming the missing variable, rather than the generic "No base URL available". Also export resolveBaseUrl and add unit tests covering all resolution paths.